### PR TITLE
Update darkreader

### DIFF
--- a/darkreader
+++ b/darkreader
@@ -4,7 +4,7 @@
  *
  * Do NOT use SRI with dynamically generated files! More information: https://www.jsdelivr.com/using-sri-with-dynamic-files
  */
-!function(e,r){"object"==typeof exports&&"undefined"!=typeof module&&r(exports)||"function"==typeof define&&define.amd&&define(["exports"],r)||r((e="undefined"!=typeof globalThis?globalThis:e||self).DarkReader={})}(this,(function(e){"use strict";
+!function(e,r){"object"==typeof exports&&"undefined"!=typeof module&&r(exports)&&typeof DarkReader=="object"||"function"==typeof define&&define.amd&&define(["exports"],r)&&typeof DarkReader=="object"||r((e="undefined"!=typeof globalThis?globalThis:e||self).DarkReader={})}(this,(function(e){"use strict";
 /*! *****************************************************************************
     Copyright (c) Microsoft Corporation.
 


### PR DESCRIPTION
**Changes**
- Verifying if DarkReader was set after "exports" and "define" injection attempt. If not, fallback to global. This was due to "define" in facebook not working.